### PR TITLE
disable LTO on x86_64 and znver1

### DIFF
--- a/dav1d.spec
+++ b/dav1d.spec
@@ -2,13 +2,13 @@
 %define         libname %mklibname %{name}
 %define         devel %mklibname %{name} -d
 
-%ifarch %{arm} %{armx}
+%ifarch %{arm} %{armx} x86_64 znver1
 %define _disable_lto 1
 %endif
 
 Name:     dav1d
 Version:	0.8.1
-Release:	1
+Release:	2
 License:  BSD
 Group:    System/Libraries
 Summary:  AV1 cross-platform Decoder


### PR DESCRIPTION
LTO in combination with Clang results in segfault when trying to use AVX2 asm which is going to get picked by default on every znver1 machine and also significant amount of x86_64 machines (2013 and newer). I didn't manage to reproduce this on 32-bit.
Other option to consider would be to switch to GCC (where LTO doesnt break) but with -O3 which would give significant boost over Clang (gcc -O2 is slower than clang -O2).